### PR TITLE
Harden Chrome extension MV3 permissions and background actions

### DIFF
--- a/background.js
+++ b/background.js
@@ -113,13 +113,26 @@ function hostnameMatch(enabledSites, hostname) {
     });
 }
 
+function findMatchedSite(enabledSites, hostname) {
+    if (!hostname || !Array.isArray(enabledSites)) return null;
+    const normalizedHostname = hostname.toLowerCase();
+    return enabledSites.find(site => {
+        if (typeof site !== 'string') return false;
+        const normalizedSite = site.toLowerCase();
+        return normalizedHostname === normalizedSite || normalizedHostname.endsWith('.' + normalizedSite);
+    }) || null;
+}
+
 function toggleHostname(enabledSites, hostname) {
     const sites = new Set(Array.isArray(enabledSites) ? enabledSites : []);
-    if (hostnameMatch(Array.from(sites), hostname)) {
-        sites.delete(hostname);
-    } else {
-        sites.add(hostname);
+    const matchedSite = findMatchedSite(Array.from(sites), hostname);
+
+    if (matchedSite) {
+        sites.delete(matchedSite);
+    } else if (hostname) {
+        sites.add(hostname.toLowerCase());
     }
+
     return Array.from(sites).sort();
 }
 
@@ -203,7 +216,7 @@ async function requestContentReload(tabId, settings) {
     let result = await sendMessageToTab(tabId, message);
     if (result.ok) return result;
 
-    const injection = await executeScriptSafely(tabId, { files: ['content.js'] });
+    const injection = await executeScriptSafely(tabId, { files: ['content.js', 'content-patch.js'] });
     if (!injection.ok) return injection;
 
     await new Promise(resolve => setTimeout(resolve, 250));
@@ -219,7 +232,7 @@ async function exportPdf(tab) {
     let result = await sendMessageToTab(tab.id, { action: 'exportPdf' });
     if (result.ok) return;
 
-    const injection = await executeScriptSafely(tab.id, { files: ['content.js'] });
+    const injection = await executeScriptSafely(tab.id, { files: ['content.js', 'content-patch.js'] });
     if (injection.ok) {
         await new Promise(resolve => setTimeout(resolve, 500));
         result = await sendMessageToTab(tab.id, { action: 'exportPdf' });

--- a/background.js
+++ b/background.js
@@ -1,7 +1,21 @@
-
 // --- Utility Promise Wrappers ---
-function getSyncStorage(defaults) {
-    return new Promise(resolve => chrome.storage.sync.get(defaults, resolve));
+const DEFAULT_SETTINGS = {
+    isEnabled: true,
+    selectedFont: 'vazir',
+    fontSize: 'default',
+    detectionMode: 'medium',
+    enabledSites: []
+};
+
+const INJECTABLE_PROTOCOLS = new Set(['http:', 'https:']);
+
+function getSyncStorage(defaults = DEFAULT_SETTINGS) {
+    return new Promise((resolve, reject) => {
+        chrome.storage.sync.get(defaults, (result) => {
+            if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+            else resolve(result);
+        });
+    });
 }
 
 function setSyncStorage(data) {
@@ -13,19 +27,39 @@ function setSyncStorage(data) {
     });
 }
 
+function isInjectableUrl(tabUrl) {
+    try {
+        if (!tabUrl) return false;
+        return INJECTABLE_PROTOCOLS.has(new URL(tabUrl).protocol);
+    } catch (_) {
+        return false;
+    }
+}
+
+function getHostname(tabUrl) {
+    try {
+        if (!isInjectableUrl(tabUrl)) return '';
+        return new URL(tabUrl).hostname.toLowerCase();
+    } catch (_) {
+        return '';
+    }
+}
+
 // --- Context Menu Creation ---
 let contextMenusCreating = false;
 let contextMenusTimeout = null;
+
 function createContextMenus() {
-    if (contextMenusCreating) return;
+    if (contextMenusCreating || !chrome.contextMenus) return;
     contextMenusCreating = true;
-    // Safety timeout to reset guard in case of unexpected issues
     clearTimeout(contextMenusTimeout);
     contextMenusTimeout = setTimeout(() => { contextMenusCreating = false; }, 5000);
+
     chrome.contextMenus.removeAll(() => {
         if (chrome.runtime.lastError) {
-            console.warn('removeAll failed:', chrome.runtime.lastError);
+            console.warn('removeAll failed:', chrome.runtime.lastError.message);
         }
+
         const menus = [
             {
                 id: 'rtl_parent',
@@ -51,11 +85,12 @@ function createContextMenus() {
                 contexts: ['all']
             }
         ];
+
         let created = 0;
         menus.forEach(menu => {
             chrome.contextMenus.create(menu, () => {
                 if (chrome.runtime.lastError) {
-                    console.warn('create failed for', menu.id, ':', chrome.runtime.lastError);
+                    console.warn('create failed for', menu.id, ':', chrome.runtime.lastError.message);
                 }
                 created++;
                 if (created === menus.length) {
@@ -69,9 +104,23 @@ function createContextMenus() {
 
 // --- Subdomain Matching ---
 function hostnameMatch(enabledSites, hostname) {
-    return enabledSites.some(
-        site => hostname === site || hostname.endsWith('.' + site)
-    );
+    if (!hostname || !Array.isArray(enabledSites)) return false;
+    const normalizedHostname = hostname.toLowerCase();
+    return enabledSites.some(site => {
+        if (typeof site !== 'string') return false;
+        const normalizedSite = site.toLowerCase();
+        return normalizedHostname === normalizedSite || normalizedHostname.endsWith('.' + normalizedSite);
+    });
+}
+
+function toggleHostname(enabledSites, hostname) {
+    const sites = new Set(Array.isArray(enabledSites) ? enabledSites : []);
+    if (hostnameMatch(Array.from(sites), hostname)) {
+        sites.delete(hostname);
+    } else {
+        sites.add(hostname);
+    }
+    return Array.from(sites).sort();
 }
 
 // --- Icon Paths Utility ---
@@ -106,20 +155,80 @@ function debounceUpdateIcon(tabId, url) {
 async function updateIconForTab(tabId, tabUrl) {
     try {
         if (!tabUrl) {
-            const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-            if (tab && tab.id === tabId) tabUrl = tab.url || '';
+            const tab = await chrome.tabs.get(tabId).catch(() => null);
+            tabUrl = tab?.url || '';
         }
-        if (!tabUrl || tabUrl.startsWith('chrome://') || tabUrl.startsWith('chrome-extension://')) {
+
+        if (!isInjectableUrl(tabUrl)) {
             await chrome.action.setIcon({ tabId, path: getIconPaths(false) });
             return;
         }
-        const hostname = new URL(tabUrl).hostname;
-        const defaults = { enabledSites: [] };
-        const settings = await getSyncStorage(defaults);
-        const enabled = Array.isArray(settings.enabledSites) && hostnameMatch(settings.enabledSites, hostname);
+
+        const hostname = getHostname(tabUrl);
+        const settings = await getSyncStorage(DEFAULT_SETTINGS);
+        const enabled = hostnameMatch(settings.enabledSites, hostname);
         await chrome.action.setIcon({ tabId, path: getIconPaths(enabled) });
     } catch (e) {
         console.error('updateIconForTab error:', e);
+    }
+}
+
+function sendMessageToTab(tabId, message) {
+    return new Promise(resolve => {
+        try {
+            chrome.tabs.sendMessage(tabId, message, response => {
+                if (chrome.runtime.lastError) {
+                    resolve({ ok: false, error: chrome.runtime.lastError.message });
+                    return;
+                }
+                resolve({ ok: true, response });
+            });
+        } catch (error) {
+            resolve({ ok: false, error: error.message });
+        }
+    });
+}
+
+async function executeScriptSafely(tabId, details) {
+    try {
+        await chrome.scripting.executeScript({ target: { tabId }, ...details });
+        return { ok: true };
+    } catch (error) {
+        return { ok: false, error: error.message };
+    }
+}
+
+async function requestContentReload(tabId, settings) {
+    const message = { action: 'fullReload', ...settings };
+    let result = await sendMessageToTab(tabId, message);
+    if (result.ok) return result;
+
+    const injection = await executeScriptSafely(tabId, { files: ['content.js'] });
+    if (!injection.ok) return injection;
+
+    await new Promise(resolve => setTimeout(resolve, 250));
+    return sendMessageToTab(tabId, message);
+}
+
+async function exportPdf(tab) {
+    if (!tab?.id || !isInjectableUrl(tab.url)) {
+        console.warn('Export skipped: unsupported tab URL');
+        return;
+    }
+
+    let result = await sendMessageToTab(tab.id, { action: 'exportPdf' });
+    if (result.ok) return;
+
+    const injection = await executeScriptSafely(tab.id, { files: ['content.js'] });
+    if (injection.ok) {
+        await new Promise(resolve => setTimeout(resolve, 500));
+        result = await sendMessageToTab(tab.id, { action: 'exportPdf' });
+        if (result.ok) return;
+    }
+
+    const printFallback = await executeScriptSafely(tab.id, { func: () => window.print() });
+    if (!printFallback.ok) {
+        console.error('Export PDF failed:', result.error || injection.error || printFallback.error);
     }
 }
 
@@ -136,158 +245,98 @@ if (chrome.runtime.onStartup) {
     });
 }
 
-chrome.contextMenus && chrome.contextMenus.onClicked.addListener(async (info, tab) => {
-    try {
-        if (!tab || !tab.id || !tab.url) return;
-        const url = new URL(tab.url);
-        const hostname = url.hostname;
-        const defaults = {
-            isEnabled: true,
-            selectedFont: 'vazir',
-            fontSize: 'default',
-            detectionMode: 'medium',
-            enabledSites: []
-        };
+if (chrome.contextMenus) {
+    chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+        try {
+            if (!tab?.id || !isInjectableUrl(tab.url)) return;
+            const hostname = getHostname(tab.url);
+            if (!hostname) return;
 
-        if (info.menuItemId === 'rtl_toggle_current_domain') {
-            let settings;
-            try {
-                settings = await getSyncStorage(defaults);
-                const enabledSites = new Set(settings.enabledSites || []);
-                if (hostnameMatch(Array.from(enabledSites), hostname)) {
-                    enabledSites.delete(hostname);
-                } else {
-                    enabledSites.add(hostname);
-                }
-                await setSyncStorage({ enabledSites: Array.from(enabledSites) });
-                // Trigger full reload
-                chrome.tabs.sendMessage(tab.id, { action: 'fullReload', ...settings }, () => {});
-                const isNowEnabled = enabledSites.has(hostname);
-                try { chrome.action.setIcon({ tabId: tab.id, path: getIconPaths(isNowEnabled) }); } catch (e) { console.error(e); }
-            } catch (err) {
-                console.error('Toggle domain failed:', err);
-            }
-        }
+            if (info.menuItemId === 'rtl_toggle_current_domain') {
+                const settings = await getSyncStorage(DEFAULT_SETTINGS);
+                const enabledSites = toggleHostname(settings.enabledSites, hostname);
+                const nextSettings = { ...settings, enabledSites };
 
-        if (info.menuItemId === 'rtl_apply_reload') {
-            const settings = await getSyncStorage(defaults);
-            try {
-                chrome.tabs.sendMessage(tab.id, { action: 'fullReload', ...settings }, () => {});
-            } catch (err) {
-                console.error('Apply reload failed:', err);
-            }
-        }
+                await setSyncStorage({ enabledSites });
+                await requestContentReload(tab.id, nextSettings);
 
-        if (info.menuItemId === 'rtl_export_pdf') {
-            try {
-                // First, try to send message to existing content script
-                chrome.tabs.sendMessage(tab.id, { action: 'exportPdf' }, (response) => {
-                    if (chrome.runtime.lastError) {
-                        console.log('Content script not available, attempting injection...');
-                        
-                        // Try to inject content script
-                        chrome.scripting.executeScript({
-                            target: { tabId: tab.id },
-                            files: ['content.js']
-                        }).then(() => {
-                            setTimeout(() => {
-                                chrome.tabs.sendMessage(tab.id, { action: 'exportPdf' }, (response) => {
-                                    if (chrome.runtime.lastError) {
-                                        console.log('Export via content script failed, using native print...');
-                                        chrome.scripting.executeScript({
-                                            target: { tabId: tab.id },
-                                            func: () => window.print()
-                                        });
-                                    }
-                                });
-                            }, 500);
-                        }).catch(injectionError => {
-                            console.error('Content script injection failed:', injectionError.message);
-                            console.log('Using native browser print as fallback...');
-                            // Direct native print fallback when injection fails
-                            chrome.scripting.executeScript({
-                                target: { tabId: tab.id },
-                                func: () => window.print()
-                            }).catch(printError => {
-                                console.error('All print methods failed:', printError);
-                                // Try alternative method for policy-restricted pages
-                                chrome.tabs.create({
-                                    url: `javascript:window.print()`
-                                });
-                            });
-                        });
-                    }
-                });
-            } catch (e) {
-                console.error('Export PDF failed:', e);
-                // Final fallback - try direct print
-                try {
-                    chrome.scripting.executeScript({
-                        target: { tabId: tab.id },
-                        func: () => window.print()
-                    });
-                } catch (printError) {
-                    console.error('Native print also failed:', printError);
-                    // Try opening a new tab with print dialog
-                    chrome.tabs.create({
-                        url: `javascript:window.print()`
-                    });
-                }
+                const isNowEnabled = hostnameMatch(enabledSites, hostname);
+                await chrome.action.setIcon({ tabId: tab.id, path: getIconPaths(isNowEnabled) });
+                return;
             }
+
+            if (info.menuItemId === 'rtl_apply_reload') {
+                const settings = await getSyncStorage(DEFAULT_SETTINGS);
+                await requestContentReload(tab.id, settings);
+                return;
+            }
+
+            if (info.menuItemId === 'rtl_export_pdf') {
+                await exportPdf(tab);
+            }
+        } catch (e) {
+            console.error('Context menu handler error:', e);
         }
-    } catch (e) {
-        console.error('Context menu handler error:', e);
-    }
-});
+    });
+}
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.action === 'heartbeat') {
-        console.log('Heartbeat received from:', message.domain, 'Stats:', message.stats);
-        // Store or process stats
+    if (message?.action === 'heartbeat') {
+        const domain = typeof message.domain === 'string' ? message.domain : 'unknown';
         chrome.storage.local.set({
-            [`heartbeat_${message.domain}`]: {
-                timestamp: message.timestamp,
-                stats: message.stats
+            [`heartbeat_${domain}`]: {
+                timestamp: message.timestamp || Date.now(),
+                stats: message.stats || {}
             }
         });
-        // Set ON icon for the sender tab
-        try { if (sender && sender.tab && sender.tab.id) chrome.action.setIcon({ tabId: sender.tab.id, path: getIconPaths(true) }); } catch (e) { console.error(e); }
+
+        try {
+            if (sender?.tab?.id) chrome.action.setIcon({ tabId: sender.tab.id, path: getIconPaths(true) });
+        } catch (e) {
+            console.error(e);
+        }
+
         sendResponse({ success: true });
         return true;
     }
 
-    
-    return true;
+    sendResponse({ success: false, error: 'Unknown action' });
+    return false;
 });
 
 // --- Storage Change Handling ---
 chrome.storage.onChanged.addListener((changes, namespace) => {
     if (namespace === 'sync') {
-        console.log('Settings changed:', changes);
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
             const tab = tabs && tabs[0];
-            if (tab && tab.id) debounceUpdateIcon(tab.id, tab.url || '');
+            if (tab?.id) debounceUpdateIcon(tab.id, tab.url || '');
         });
     }
 });
 
 // --- Clean up pending icon updates when tabs are closed ---
-chrome.tabs.onRemoved && chrome.tabs.onRemoved.addListener((tabId) => {
-    if (iconUpdateQueue[tabId]) {
-        clearTimeout(iconUpdateQueue[tabId]);
-        delete iconUpdateQueue[tabId];
-    }
-});
+if (chrome.tabs.onRemoved) {
+    chrome.tabs.onRemoved.addListener((tabId) => {
+        if (iconUpdateQueue[tabId]) {
+            clearTimeout(iconUpdateQueue[tabId]);
+            delete iconUpdateQueue[tabId];
+        }
+    });
+}
 
-chrome.tabs.onActivated && chrome.tabs.onActivated.addListener(async (activeInfo) => {
-    try {
-        const tab = await chrome.tabs.get(activeInfo.tabId);
-        debounceUpdateIcon(activeInfo.tabId, tab.url || '');
-    } catch (e) { console.error(e); }
-});
+if (chrome.tabs.onActivated) {
+    chrome.tabs.onActivated.addListener(async (activeInfo) => {
+        try {
+            const tab = await chrome.tabs.get(activeInfo.tabId);
+            debounceUpdateIcon(activeInfo.tabId, tab.url || '');
+        } catch (e) { console.error(e); }
+    });
+}
 
-chrome.tabs.onUpdated && chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    if (changeInfo.status === 'complete') {
-        debounceUpdateIcon(tabId, tab.url || '');
-    }
-});
+if (chrome.tabs.onUpdated) {
+    chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+        if (changeInfo.status === 'complete') {
+            debounceUpdateIcon(tabId, tab.url || '');
+        }
+    });
+}

--- a/content-patch.js
+++ b/content-patch.js
@@ -1,0 +1,86 @@
+(() => {
+    'use strict';
+
+    const PATCH_FLAG = '__rtlFixancerDomainPatchApplied';
+    const MAX_ATTEMPTS = 80;
+    const RETRY_DELAY_MS = 100;
+
+    function getCurrentDomain() {
+        try {
+            return window.location.hostname.toLowerCase();
+        } catch (_) {
+            return '';
+        }
+    }
+
+    function domainMatches(enabledSites, hostname) {
+        if (!hostname || !Array.isArray(enabledSites)) return false;
+        const normalizedHostname = hostname.toLowerCase();
+
+        return enabledSites.some(site => {
+            if (typeof site !== 'string') return false;
+            const normalizedSite = site.toLowerCase();
+            return normalizedHostname === normalizedSite || normalizedHostname.endsWith('.' + normalizedSite);
+        });
+    }
+
+    function patchManager(manager) {
+        if (!manager || manager[PATCH_FLAG]) return false;
+
+        manager[PATCH_FLAG] = true;
+        manager.domainMatches = domainMatches;
+        manager.isSiteEnabled = function isSiteEnabledWithSubdomains() {
+            const hostname = this.currentDomain || getCurrentDomain();
+            const sites = this.config && Array.isArray(this.config.enabledSites)
+                ? this.config.enabledSites
+                : [];
+            return domainMatches(sites, hostname);
+        };
+
+        try {
+            if (manager.config?.isEnabled && manager.isSiteEnabled() && !manager.hasInitialized) {
+                manager.startExtension();
+            }
+        } catch (error) {
+            console.warn('RTL Fixancer domain patch start failed:', error);
+        }
+
+        return true;
+    }
+
+    function patchWhenReady(attempt = 0) {
+        if (patchManager(window.rtlManagerAIStudio)) return;
+        if (attempt >= MAX_ATTEMPTS) return;
+        setTimeout(() => patchWhenReady(attempt + 1), RETRY_DELAY_MS);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => patchWhenReady(), { once: true });
+    }
+    patchWhenReady();
+
+    try {
+        chrome.storage.onChanged.addListener((changes, namespace) => {
+            if (namespace !== 'sync' || !changes.enabledSites) return;
+            const manager = window.rtlManagerAIStudio;
+            if (!manager) return;
+            patchManager(manager);
+
+            if (manager.config) {
+                manager.config.enabledSites = changes.enabledSites.newValue || [];
+            }
+
+            try {
+                const enabled = manager.config?.isEnabled && manager.isSiteEnabled();
+                if (enabled && !manager.hasInitialized) {
+                    manager.startExtension();
+                } else if (!enabled && manager.hasInitialized) {
+                    manager.cleanup();
+                    manager.hasInitialized = false;
+                }
+            } catch (error) {
+                console.warn('RTL Fixancer domain patch storage handling failed:', error);
+            }
+        });
+    } catch (_) {}
+})();

--- a/content-patch.js
+++ b/content-patch.js
@@ -25,7 +25,8 @@
     }
 
     function patchManager(manager) {
-        if (!manager || manager[PATCH_FLAG]) return false;
+        if (!manager) return false;
+        if (manager[PATCH_FLAG]) return true;
 
         manager[PATCH_FLAG] = true;
         manager.domainMatches = domainMatches;

--- a/docs/extension-audit.md
+++ b/docs/extension-audit.md
@@ -1,0 +1,90 @@
+# Chrome Extension Audit Notes
+
+Date: 2026-06-20
+
+## Scope
+
+Reviewed the extension against Manifest V3 operational and security practices:
+
+- Manifest permissions and host permissions
+- Background service worker behavior
+- Content script activation model
+- Popup-to-content messaging and script injection fallback
+- URL handling for restricted browser pages
+
+## Fixed in this PR
+
+### 1. Removed unnecessary broad host permissions
+
+The manifest had `host_permissions` with `*://*/*` plus specific hosts. The extension already uses a static content script with `<all_urls>` and an internal per-site enable list, while popup/context-menu injection can rely on user invocation through `activeTab` and `scripting`.
+
+Keeping broad `host_permissions` increases install-time warnings and violates least-privilege expectations. The PR removes the host permissions block and keeps the runtime permissions the current architecture actually needs.
+
+### 2. Aligned manifest version metadata
+
+`AGENTS.md` described the post-fix version as `3.4`, but `manifest.json` was still `3.3`. The PR updates the manifest version to `3.4` and adds `minimum_chrome_version: 88`, which is the general baseline for Manifest V3 support.
+
+### 3. Hardened background URL handling
+
+The background service worker now only attempts script injection or page printing on `http:` and `https:` pages. This avoids noisy failures on browser pages such as `chrome://`, `chrome-extension://`, `edge://`, local restricted pages, and similar protected URLs.
+
+### 4. Removed unsafe `javascript:` tab fallback
+
+The old PDF export fallback attempted to open a new tab with `javascript:window.print()`. This is brittle, unsafe, and not a reliable MV3 pattern. The PR replaces it with a single controlled `chrome.scripting.executeScript({ func: () => window.print() })` fallback and logs a safe error if that fails.
+
+### 5. Fixed stale settings dispatch after context-menu toggle
+
+The previous context-menu toggle stored a new `enabledSites` list, but sent the old settings object to the content script immediately after. The PR now builds `nextSettings` and sends the fresh state to the tab.
+
+### 6. Centralized tab messaging and injection fallback
+
+`background.js` now uses small helpers for:
+
+- URL support checks
+- hostname extraction
+- tab messaging with `runtime.lastError` handling
+- script injection with explicit error handling
+- content reload fallback
+
+This reduces duplicated callback code and prevents unhandled `runtime.lastError` noise.
+
+## Important follow-up issue not changed in this PR
+
+`background.js` uses subdomain-aware matching:
+
+```js
+hostname === site || hostname.endsWith('.' + site)
+```
+
+But `content.js` currently checks only exact domain membership:
+
+```js
+return sites.includes(this.currentDomain);
+```
+
+That can create an icon/content mismatch for subdomains. This PR intentionally did not touch `content.js` because it is a large, historically fragile file and the repo guide explicitly warns against broad edits there. Recommended targeted future fix:
+
+```js
+isSiteEnabled() {
+    if (!this.currentDomain) return false;
+    const sites = this.config && Array.isArray(this.config.enabledSites)
+        ? this.config.enabledSites
+        : [];
+    return sites.some(site => {
+        if (typeof site !== 'string') return false;
+        const normalizedSite = site.toLowerCase();
+        const normalizedDomain = this.currentDomain.toLowerCase();
+        return normalizedDomain === normalizedSite || normalizedDomain.endsWith('.' + normalizedSite);
+    });
+}
+```
+
+## Manual verification checklist
+
+1. Load the unpacked extension in Chrome.
+2. Confirm no manifest warning appears for unnecessary host permissions beyond content-script access.
+3. Open a normal `https://` page, enable the domain, and verify the icon turns on.
+4. Use context menu → re-apply and verify the page updates without console errors.
+5. Use context menu → export PDF and verify it opens the print dialog.
+6. Open `chrome://extensions` or another protected page and verify the extension fails gracefully without trying to inject scripts.
+7. Test subdomain behavior after the follow-up `content.js` fix.

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,8 @@
                 "<all_urls>"
             ],
             "js": [
-                "content.js"
+                "content.js",
+                "content-patch.js"
             ],
             "run_at": "document_start",
             "all_frames": true

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,11 @@
 {
     "manifest_version": 3,
     "name": "RTL Fixancer",
-    "version": "3.3",
+    "version": "3.4",
     "description": "بهبود و راست‌چین‌سازی هوشمند متون فارسی (Fix + Enhancer) - سازگار با محدودیتهای سیاست مرورگر",
     "author": "Nishef1",
     "homepage_url": "https://github.com/Nishef1/RTL-Fixancer",
+    "minimum_chrome_version": "88",
     "icons": {
         "16": "images/RTL-on-16.png",
         "32": "images/RTL-on-32.png",
@@ -17,12 +18,6 @@
         "scripting",
         "contextMenus",
         "tabs"
-    ],
-    "host_permissions": [
-        "*://aistudio.google.com/*",
-        "*://makersuite.google.com/*",
-        "*://perplexity.ai/*",
-        "*://*/*"
     ],
     "action": {
         "default_popup": "popup.html",


### PR DESCRIPTION
## Summary

- Removes unnecessary broad `host_permissions` including `*://*/*` from the MV3 manifest.
- Bumps manifest version to `3.4` and adds `minimum_chrome_version: 88`.
- Rewrites `background.js` URL handling so script injection and PDF export only run on supported `http:`/`https:` tabs.
- Removes the unsafe/brittle `javascript:window.print()` tab fallback.
- Sends fresh settings to the content script after context-menu domain toggles instead of stale settings.
- Adds `content-patch.js` after `content.js` to fix subdomain-aware site matching without risky refactoring of the large legacy `content.js` file.
- Fixes context-menu toggle removal so disabling a subdomain correctly removes the matched parent domain entry when the parent domain is what enabled it.
- Adds `docs/extension-audit.md` with the audit findings and manual verification checklist.

## Why

Chrome MV3 extensions should follow least-privilege permission design, avoid broad host permissions unless actually required, and handle protected browser pages gracefully. The old background fallback could try unsafe or unsupported URLs and the manifest requested more host access than the current architecture needs.

There was also a real architecture mismatch: background icon logic supported subdomains, but the content runtime only checked exact domain membership. This PR now aligns those paths while keeping the fragile `content.js` core untouched.

## Verification

- Inspected `manifest.json` after the change: valid MV3 JSON with background service worker, no `host_permissions` block, and ordered content scripts (`content.js`, then `content-patch.js`).
- Inspected `content-patch.js`: idempotent patching, retry-until-manager-ready, subdomain-aware matching, storage-change handling.
- Inspected `background.js`: centralized URL guards, safe injection fallback, fixed subdomain toggle removal.
- Compared branch with `main`: 4 files changed (`manifest.json`, `background.js`, `content-patch.js`, `docs/extension-audit.md`).

## Manual test checklist

1. Load the unpacked extension in Chrome.
2. Enable `example.com`, then open `sub.example.com` and confirm the content script activates.
3. Disable from `sub.example.com` via context menu and confirm the matched parent entry is removed.
4. Try re-apply and PDF export on a normal `https://` page.
5. Try the popup/context menu on `chrome://extensions` and confirm it fails gracefully without injection noise.